### PR TITLE
return logger for convenience

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,4 +27,5 @@ module.exports = function(logger, levels) {
     extLogFn(lvl)
   }
 
+  return logger
 }


### PR DESCRIPTION
returning `logger` instead of `undefined` makes this more convenient to use, i.e. `return colorWrap(originalLogger)`